### PR TITLE
Add application/octet-stream MIME type for .bplt files on iOS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2170,7 +2170,7 @@ const PlotAnalyzer = () => {
               clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
             }}
           >
-            <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" multiple onChange={handleFileUpload} className="hidden" />
+            <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/octet-stream" multiple onChange={handleFileUpload} className="hidden" />
 
             {isLoading ? (
               <div className="flex flex-col items-center">
@@ -2265,7 +2265,7 @@ const PlotAnalyzer = () => {
           onExport={exportToPDF}
           eventCount={bplotProcessed?.events?.length || 0}
         />
-        <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" multiple onChange={handleFileUpload} className="hidden" />
+        <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/octet-stream" multiple onChange={handleFileUpload} className="hidden" />
         <BPlotAnalysis
           data={bplotData}
           processedData={bplotProcessed}
@@ -2298,7 +2298,7 @@ const PlotAnalyzer = () => {
         onExport={exportToPDF}
         eventCount={faults?.length || 0}
       />
-      <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" multiple onChange={handleFileUpload} className="hidden" />
+      <input id="fileIn" type="file" accept=".csv,.xlsx,.xls,.bplt,text/csv,text/plain,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/octet-stream" multiple onChange={handleFileUpload} className="hidden" />
 
       <main className="w-full px-6 py-6 space-y-8 mx-auto" style={{ maxWidth: '98%' }}>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands allowed MIME types for file uploads to improve .bplt handling on iOS.
> 
> - Updates three `input#fileIn` elements in `App.jsx` to include `application/octet-stream` in their `accept` attribute
> - No processing logic or UI behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b725a89d08a6b67b835ca9b039ec5b619acd5c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->