### PR TITLE
Fix chart not rendering on mobile - add explicit height

### DIFF
--- a/src/components/BPlotAnalysis.jsx
+++ b/src/components/BPlotAnalysis.jsx
@@ -593,7 +593,7 @@ const BPlotAnalysis = ({
 
             {/* Main Chart Area */}
             <div className="flex-1 min-h-[300px] bg-slate-900/50 border border-slate-800 rounded-xl p-4 lg:p-6 flex flex-col">
-              <div className="flex-1">
+              <div className="flex-1 h-[300px] lg:h-auto">
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={chartData}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#334155" />


### PR DESCRIPTION
ResponsiveContainer with height="100%" needs a parent with defined height. On mobile with flex-col layout, flex-1 doesn't provide calculable height. Added explicit h-[300px] on mobile, lg:h-auto for desktop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes blank chart on mobile by ensuring `ResponsiveContainer` has a calculable height.
> 
> - In `BPlotAnalysis.jsx`, add `h-[300px] lg:h-auto` to the main chart container div so `height="100%"` resolves correctly on small screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b133a30b769ca7e25eb606329cd5a40940bdd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->