### PR TITLE
Fix mobile tooltip size and anomaly rule requireWhen/duration support

### DIFF
--- a/src/components/BPlotAnalysis.jsx
+++ b/src/components/BPlotAnalysis.jsx
@@ -480,7 +480,8 @@ const BPlotAnalysis = ({
                     <YAxis yAxisId="rpm" stroke="#3b82f6" fontSize={12} domain={[0, 'auto']} />
                     <YAxis yAxisId="map" orientation="right" stroke="#8b5cf6" fontSize={12} />
                     <Tooltip
-                      contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155' }}
+                      wrapperStyle={{ maxWidth: '90vw', fontSize: '12px' }}
+                      contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', padding: '8px', maxWidth: '280px' }}
                       labelFormatter={(v) => `Time: ${formatDuration(v)}`}
                       formatter={(value, name) => {
                         if (typeof value === 'number') {
@@ -627,7 +628,8 @@ const BPlotAnalysis = ({
                       />
                     ))}
                     <Tooltip
-                      contentStyle={{ backgroundColor: 'rgba(15, 23, 42, 0.95)', border: '1px solid #334155', borderRadius: '6px' }}
+                      wrapperStyle={{ maxWidth: '90vw', fontSize: '12px' }}
+                      contentStyle={{ backgroundColor: 'rgba(15, 23, 42, 0.95)', border: '1px solid #334155', borderRadius: '6px', padding: '8px', maxWidth: '280px' }}
                       labelFormatter={(v, payload) => {
                         const sourceFile = payload?.[0]?.payload?._sourceFile;
                         if (sourceFile && fileBoundaries.length > 1) {


### PR DESCRIPTION
Tooltip fixes:
- Added maxWidth constraint (280px) for tooltips on mobile
- Reduced wrapper size to 90vw max to prevent full-screen takeover

Anomaly engine fixes:
- Added requireWhen condition support for custom anomaly rules
- Rules with requireWhen only trigger when ALL requirements are met
- Added per-rule duration filtering (e.g., dtc-active requires 5s)
- Alerts shorter than rule's duration threshold are now filtered out

This ensures DTC/MIL warnings only appear when:
1. Engine is running (RPM >= 500) via requireWhen
2. Condition persists for minimum duration (5 seconds)