### PR TITLE
Fix BPLT conversion: seek to data section when header is pre-read

### DIFF
--- a/server/python/bplt_reader_core.py
+++ b/server/python/bplt_reader_core.py
@@ -303,6 +303,9 @@ def read_bplt_file(file_path: str, debug: bool = False, header: dict | None = No
     with open(file_path, 'rb') as f:
         if header is None:
             header = read_header_from_handle(f, debug=debug)
+        else:
+            # Seek to data section when header was pre-read
+            f.seek(header['header_position'])
         data = read_data(f, header['channel_names'], header, debug=debug)
         return {
             'header': header,


### PR DESCRIPTION
When convert_bplt_to_csv pre-reads the header for size validation, then passes it to read_bplt_file, the file was reopened at position 0 but header reading was skipped - causing all channel reads to fail with "missing count bytes" errors.