### PR TITLE
Add database persistence for baseline/anomaly detection data

### DIFF
--- a/server/db/schema.js
+++ b/server/db/schema.js
@@ -70,6 +70,29 @@ export async function ensureUploadsTable() {
   `);
 }
 
+export async function ensureBaselinesTables() {
+  const pool = getPool();
+  if (!pool) return;
+
+  // Main baseline data storage
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS baseline_data (
+      id INTEGER PRIMARY KEY DEFAULT 1,
+      payload JSONB NOT NULL,
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+
+  // Baseline index (groups, sizes, applications metadata)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS baseline_index (
+      id INTEGER PRIMARY KEY DEFAULT 1,
+      payload JSONB NOT NULL,
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
 export async function ensureAllTables() {
   console.log('Starting database table creation...');
   try {
@@ -77,7 +100,8 @@ export async function ensureAllTables() {
       ensureIssuesTable(),
       ensureProfilesTables(),
       ensureConfiguratorAuditTable(),
-      ensureUploadsTable()
+      ensureUploadsTable(),
+      ensureBaselinesTables()
     ]);
     console.log('Database tables created successfully');
   } catch (error) {

--- a/server/utils/baselineStore.js
+++ b/server/utils/baselineStore.js
@@ -2,6 +2,8 @@ import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { getPool } from '../db/pool.js';
+import { ensureBaselinesTables } from '../db/schema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,6 +18,14 @@ const DEFAULT_INDEX = {
   sizes: [],
   applications: []
 };
+
+const pool = getPool();
+
+async function useDatabase() {
+  if (!pool) return false;
+  await ensureBaselinesTables();
+  return true;
+}
 
 function normalizeName(value) {
   return String(value || '').trim();
@@ -57,16 +67,84 @@ function buildIndexFromData(baselineData) {
 }
 
 async function saveIndex(index) {
+  // Save to DB if available
+  const dbReady = await useDatabase();
+  if (dbReady) {
+    await pool.query(
+      `INSERT INTO baseline_index (id, payload, updated_at)
+       VALUES (1, $1, NOW())
+       ON CONFLICT (id) DO UPDATE SET payload = $1, updated_at = NOW()`,
+      [index]
+    );
+  }
+
+  // Also write to disk for backward compatibility
   const payload = JSON.stringify(index, null, 2);
   await fs.writeFile(BASELINE_INDEX_PATH, payload, 'utf8');
 }
 
+async function saveBaselineData(data) {
+  // Save to DB if available
+  const dbReady = await useDatabase();
+  if (dbReady) {
+    await pool.query(
+      `INSERT INTO baseline_data (id, payload, updated_at)
+       VALUES (1, $1, NOW())
+       ON CONFLICT (id) DO UPDATE SET payload = $1, updated_at = NOW()`,
+      [data]
+    );
+  }
+
+  // Also write to disk for backward compatibility
+  const payload = JSON.stringify(data, null, 2);
+  await fs.writeFile(BASELINE_DATA_PATH, payload, 'utf8');
+}
+
 export async function loadBaselineData() {
+  // Try database first
+  const dbReady = await useDatabase();
+  if (dbReady) {
+    const result = await pool.query('SELECT payload FROM baseline_data WHERE id = 1');
+    if (result.rows.length > 0) {
+      return result.rows[0].payload;
+    }
+  }
+
+  // Fall back to file
   const raw = await fs.readFile(BASELINE_DATA_PATH, 'utf8');
-  return JSON.parse(raw);
+  const data = JSON.parse(raw);
+
+  // Seed the database with file data if DB is available but empty
+  if (dbReady) {
+    await pool.query(
+      `INSERT INTO baseline_data (id, payload, updated_at)
+       VALUES (1, $1, NOW())
+       ON CONFLICT (id) DO NOTHING`,
+      [data]
+    );
+  }
+
+  return data;
 }
 
 export async function loadBaselineIndex() {
+  // Try database first
+  const dbReady = await useDatabase();
+  if (dbReady) {
+    const result = await pool.query('SELECT payload FROM baseline_index WHERE id = 1');
+    if (result.rows.length > 0) {
+      const parsed = result.rows[0].payload;
+      return {
+        ...DEFAULT_INDEX,
+        ...parsed,
+        groups: Array.isArray(parsed.groups) ? parsed.groups : [],
+        sizes: Array.isArray(parsed.sizes) ? parsed.sizes : [],
+        applications: Array.isArray(parsed.applications) ? parsed.applications : []
+      };
+    }
+  }
+
+  // Fall back to file or build from data
   if (!existsSync(BASELINE_INDEX_PATH)) {
     const data = await loadBaselineData();
     const index = buildIndexFromData(data);
@@ -76,13 +154,25 @@ export async function loadBaselineIndex() {
 
   const raw = await fs.readFile(BASELINE_INDEX_PATH, 'utf8');
   const parsed = JSON.parse(raw);
-  return {
+  const index = {
     ...DEFAULT_INDEX,
     ...parsed,
     groups: Array.isArray(parsed.groups) ? parsed.groups : [],
     sizes: Array.isArray(parsed.sizes) ? parsed.sizes : [],
     applications: Array.isArray(parsed.applications) ? parsed.applications : []
   };
+
+  // Seed the database with file data if DB is available but empty
+  if (dbReady) {
+    await pool.query(
+      `INSERT INTO baseline_index (id, payload, updated_at)
+       VALUES (1, $1, NOW())
+       ON CONFLICT (id) DO NOTHING`,
+      [index]
+    );
+  }
+
+  return index;
 }
 
 export async function addBaselineGroup(name) {
@@ -215,4 +305,48 @@ export async function setApplicationArchived(groupName, sizeName, appName, archi
   index.lastUpdated = new Date().toISOString();
   await saveIndex(index);
   return index;
+}
+
+/**
+ * Update baseline data for a specific application
+ */
+export async function updateBaselineData(groupName, sizeName, appName, channelData) {
+  const group = normalizeName(groupName);
+  const size = normalizeName(sizeName);
+  const app = normalizeName(appName);
+
+  if (!group || !size || !app) {
+    throw new Error('Group, size, and application are required');
+  }
+
+  const data = await loadBaselineData();
+
+  // Ensure nested structure exists
+  if (!data.groups) data.groups = {};
+  if (!data.groups[group]) data.groups[group] = {};
+  if (!data.groups[group][size]) data.groups[group][size] = {};
+
+  // Update the channel data for this application
+  data.groups[group][size][app] = channelData;
+
+  // Save to both DB and file
+  await saveBaselineData(data);
+
+  // Ensure index is updated
+  await addBaselineApplication(group, size, app);
+
+  return data;
+}
+
+/**
+ * Get baseline data for a specific application
+ */
+export async function getBaselineForApplication(groupName, sizeName, appName) {
+  const group = normalizeName(groupName);
+  const size = normalizeName(sizeName);
+  const app = normalizeName(appName);
+
+  const data = await loadBaselineData();
+
+  return data?.groups?.[group]?.[size]?.[app] || null;
 }


### PR DESCRIPTION
- Add baseline_data and baseline_index tables to schema
- Update baselineStore.js to use DB when available, fall back to files
- Auto-seed DB from JSON files on first access
- Write to both DB and files for backward compatibility
- Add updateBaselineData() and getBaselineForApplication() helpers

This ensures baseline configurations persist across Render deploys.