### PR TITLE
Add MIL Status and engine state params to parameter catalog

### DIFF
--- a/src/lib/parameterCatalog.js
+++ b/src/lib/parameterCatalog.js
@@ -831,6 +831,67 @@ export const PARAMETER_CATALOG = {
     applicableEngines: ['40L', '53L'] // v3.1.3: MFG fuel system only on 40L/53L
   },
 
+  // ============== ENGINE STATE / STATUS ==============
+  milStatus: {
+    id: 'milStatus',
+    name: 'MIL Status',
+    category: 'engine',
+    unit: '',
+    description: 'Malfunction Indicator Lamp status. 0 = No active DTC, 1 = Active DTC.',
+    dataColumns: ['MILout_mirror', 'mil_status', 'MIL_status'],
+    thresholdType: THRESHOLD_TYPES.CUSTOM,
+    evaluated: false,
+    defaults: { enabled: false },
+    validation: { min: 0, max: 1, step: 1 },
+    advanced: [],
+    engineFamilies: null
+  },
+
+  fuelControlMode: {
+    id: 'fuelControlMode',
+    name: 'Fuel Control Mode',
+    category: 'engine',
+    unit: '',
+    description: 'Fuel control loop state. 0 = Open Loop, 2 = Closed Loop, 3 = CL + Adaptive.',
+    dataColumns: ['fuel_ctl_mode', 'fuel_control_mode'],
+    thresholdType: THRESHOLD_TYPES.CUSTOM,
+    evaluated: false,
+    defaults: { enabled: false },
+    validation: { min: 0, max: 3, step: 1 },
+    advanced: [],
+    engineFamilies: null
+  },
+
+  runMode: {
+    id: 'runMode',
+    name: 'System Run Mode',
+    category: 'engine',
+    unit: '',
+    description: 'Engine operating state. 0 = Stopped, 1 = Cranking, 2 = Warmup, 3 = Running.',
+    dataColumns: ['run_mode', 'system_run_mode'],
+    thresholdType: THRESHOLD_TYPES.CUSTOM,
+    evaluated: false,
+    defaults: { enabled: false },
+    validation: { min: 0, max: 3, step: 1 },
+    advanced: [],
+    engineFamilies: null
+  },
+
+  engineLoad: {
+    id: 'engineLoad',
+    name: 'Engine Load',
+    category: 'engine',
+    unit: '%',
+    description: 'Calculated engine load percentage.',
+    dataColumns: ['engine_load', 'load_pct', 'ENGINE_LOAD'],
+    thresholdType: THRESHOLD_TYPES.CUSTOM,
+    evaluated: false,
+    defaults: { enabled: false },
+    validation: { min: 0, max: 100, step: 1 },
+    advanced: [],
+    engineFamilies: null
+  },
+
   // ============== SIGNAL QUALITY ==============
   signalQuality: {
     id: 'signalQuality',


### PR DESCRIPTION
The anomaly rule trigger condition dropdown was missing critical engine state parameters because they existed in BPLOT_PARAMETERS but not in PARAMETER_CATALOG (which feeds the RuleBuilder dropdown).

Added to catalog:
- MIL Status (MILout_mirror) - DTC active/inactive
- Fuel Control Mode (fuel_ctl_mode) - Open/Closed loop state
- System Run Mode (run_mode) - Stopped/Cranking/Warmup/Running
- Engine Load (engine_load) - Load percentage

The existing "Active Diagnostic Trouble Code" anomaly rule uses MILout_mirror as its trigger param, which now matches the catalog entry's primary dataColumn.