### PR TITLE
Fix React #185 infinite loop and last ResponsiveContainer sizing warning

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -908,7 +908,7 @@ const ECTBarChart = ({ histogram }) => {
       {/* Chart */}
       <div className="p-6">
         <div className="h-72">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
             <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 60 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#344d65" vertical={false} />
               <XAxis

--- a/src/components/BPlotAnalysis.jsx
+++ b/src/components/BPlotAnalysis.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import {
   XAxis, YAxis, CartesianGrid, Tooltip, Legend,
   ResponsiveContainer, LineChart, Line, AreaChart, Area, ReferenceLine, ReferenceArea, Brush
@@ -449,7 +449,10 @@ const BPlotAnalysis = ({
   const activeCorrelatedRole = (
     externalCorrelatedRole === 'secondary' || externalCorrelatedRole === 'primary'
   ) ? externalCorrelatedRole : internalCorrelatedRole;
-  const setCorrelatedRole = onCorrelatedRoleChange || setInternalCorrelatedRole;
+  const setCorrelatedRole = useCallback(
+    (role) => (onCorrelatedRoleChange || setInternalCorrelatedRole)(role),
+    [onCorrelatedRoleChange]
+  );
 
   useEffect(() => {
     if (!dualRoleMode) return;


### PR DESCRIPTION
- Wrap setCorrelatedRole in useCallback to stabilize reference in useEffect dependency array, preventing infinite re-render loop
- Add minWidth={0} minHeight={0} to ResponsiveContainer in App.jsx ECT histogram chart (last remaining instance)